### PR TITLE
Change object counts in counter example to int64_t

### DIFF
--- a/example_counter.cc
+++ b/example_counter.cc
@@ -18,9 +18,9 @@ using namespace osmpbfreader;
 // We need to define a visitor with three methods that will be called while the file is read
 struct Counter {
     // Three integers count how many times each object type occurs
-    int nodes;
-    int ways;
-    int relations;
+    int64_t nodes;
+    int64_t ways;
+    int64_t relations;
 
     Counter() : nodes(0), ways(0), relations(0) {}
 


### PR DESCRIPTION
Recent planet exports contain way more nodes than `int` can handle resulting in overflow in `example_counter.cc`. Switching to `int64_t` will fix the issue.

Also changes types of `ways` and `relations` counters to avoid future problems
